### PR TITLE
Added flip cards transition; added REFERENCES.md

### DIFF
--- a/src/REFERENCES.md
+++ b/src/REFERENCES.md
@@ -1,0 +1,5 @@
+#### Online references
+
+- [Pure CSS Flip Cards using Bootstrap 4 and CSS Grid [No JS]](https://nicolaskadis.info/posts/pure-css-flip-cards-using-bootstrap-4-and-css-grid-no-js)
+
+  Bootstrap and CSS combination for a clean card flip

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -9,8 +9,17 @@ export default function Card(props) {
       {cards.map((card) => {
         return (
           <div key={card.id} className="text-info">
-            <div className="Card">
-              <Jumbotron key={card.id}>{card.wordEn}</Jumbotron>
+            <div className="Card2">
+              <div className="row-lg-4 card-container">
+                <div className="card-flip">
+                  <div className="card front">
+                    <Jumbotron key={card.id}>{card.wordEn}</Jumbotron>
+                  </div>
+                  <div className="card back">
+                    <Jumbotron key={card.id}>{card.wordNl}</Jumbotron>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         );

--- a/src/pages/CollectionPage.js
+++ b/src/pages/CollectionPage.js
@@ -29,7 +29,8 @@ const CollectionPage = () => {
           return (
             <div key={collection.id}>
               <Jumbotron>
-                <h1>{collection.name}</h1>
+                <h1>{collection.name}</h1>{" "}
+                <h5>{collection.cards.length} cards</h5>
               </Jumbotron>
 
               <div style={cardStyle} key={collection.cards.id}>

--- a/src/style/Global.css
+++ b/src/style/Global.css
@@ -1,5 +1,6 @@
 .collectionCard,
-.Card {
+.Card,
+.Card2 {
   font-weight: bold;
   text-decoration: none;
   text-transform: uppercase;
@@ -10,3 +11,42 @@
 a.text-info:link {
   text-decoration: none;
 }
+
+/*flipping card transition*/
+.card-container {
+  perspective: 700px;
+}
+
+.card-flip,
+.card-container {
+  transform-style: preserve-3d;
+  transition: all 0.6s ease;
+}
+
+.card-flip div {
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+  border: 0px;
+}
+
+.front {
+  grid-area: frontAndBack;
+}
+
+.back {
+  grid-area: frontAndBack;
+  transform: rotateY(-180deg);
+}
+
+.card-container:hover .card-flip {
+  transform: rotateY(180deg);
+}
+
+.card-flip {
+  display: grid;
+  grid-template: 1fr / 1fr;
+  grid-template-areas: "frontAndBack";
+  transform-style: preserve-3d;
+  transition: all 0.6s ease;
+}
+/*end of flipping card transition*/


### PR DESCRIPTION
- Added flip cards component transition effect (still unable to map cards horizontally, it's apparently known that React ignores inline flex properties so I don't expect a quick fix? => this will be a later issue on grid view (for editing purposes), as next feature will implement some Carousel to show one card at a time on CollectionPage)
- Added `REFERENCES.md` file for further reference about combining Bootstrap and CSS Grid