### PR TITLE
Added logic to limit paths access if loggedOut; added progress bar to carousel-like card display

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -7,3 +7,7 @@
 - [JavaScript % (modulo) gives a negative result for negative numbers](https://stackoverflow.com/a/17323608)
 
   No card displayed if `index < 0` in `src/components/Card.js`.
+
+- [Advanced Association Concepts - Eager loading - Nested eager loading](https://sequelize.org/master/manual/eager-loading.html#nested-eager-loading)
+
+  Nested eager loading needed to retrieve all structured user data to display in user profile (see `flashcardapp-server/routers/users.js`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11503,6 +11503,11 @@
         "workbox-webpack-plugin": "4.3.1"
       }
     },
+    "react-speech-kit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-speech-kit/-/react-speech-kit-3.0.0.tgz",
+      "integrity": "sha512-xnnWXcTWf7Bcy/KoIncmOZ4fwprhHPhX6wjBo+GJSJ+XRKZDI96JG/8wxYYkYBPgVgmRxMSyd0Dywic3vA3AQA=="
+    },
     "react-transition-group": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.0",
+    "react-speech-kit": "^3.0.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,8 @@ import MessageBox from "./components/MessageBox";
 import SignUp from "./pages/SignUp";
 import Login from "./pages/Login";
 import Home from "./pages/Home";
-// import UserPage from "./pages/UserPage";
+import UserPage from "./pages/UserPage";
+import EditPage from "./pages/EditPage";
 import CollectionPage from "./pages/CollectionPage";
 
 import { useDispatch, useSelector } from "react-redux";
@@ -31,22 +32,25 @@ function App() {
       <Navigation />
       <MessageBox />
       {isLoading ? <Loading /> : null}
-      <Switch>
-        <Route exact path="/" component={Home} />
-        <Route path="/collections/:id" component={CollectionPage} />
-        {/* {token ? (
-          <Route path="/profile" component={UserPage} />
-        ) : (
-          <Route path="/profile" component={Home} />
-        )}
-        {token ? (
-          <Route path="/collection" component={CollectionPage} />
-        ) : (
-          <Route path="/collection" component={Home} />
-        )} */}
-        <Route path="/signup" component={SignUp} />
-        <Route path="/login" component={Login} />
-      </Switch>
+
+      {token ? (
+        <Switch>
+          <Route exact path="/" component={Home} />
+          <Route path="/collections/:id" component={CollectionPage} />
+          <Route path="/user" component={UserPage} />
+          <Route path="/edit" component={EditPage} />
+          <Route path="/signup" component={SignUp} />
+          <Route path="/login" component={Login} />
+        </Switch>
+      ) : (
+        <Switch>
+          <Route exact path="/" component={Home} />
+          <Route path="/collections/:id" component={Home} />
+          <Route path="/user" component={Home} />
+          <Route path="/signup" component={SignUp} />
+          <Route path="/login" component={Login} />
+        </Switch>
+      )}
     </div>
   );
 }

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,16 +1,168 @@
 import React, { useState } from "react";
 import Jumbotron from "react-bootstrap/Jumbotron";
 import Button from "react-bootstrap/Button";
+import { useParams } from "react-router-dom";
 
 export default function Card({ cards }) {
-  let [index, setIndex] = useState(0);
+  let [index, setIndex] = useState(1);
   const cardCount = cards.length;
+  const routeParameters = useParams();
+  const ID = parseInt(routeParameters.id);
+
+  const widthProgressBar = (100 / cardCount) * index;
+
+  if (index === 1) {
+    return (
+      <div>
+        {cards.map((card, cardIndex) => {
+          //see REFERENCES.md
+          if (
+            cardIndex === ((index % cardCount) + cardCount) % cardCount &&
+            card.collectionId === ID
+          ) {
+            return (
+              <div key={card.id} className="text-info">
+                <div className="Card2">
+                  <div className="card-container">
+                    <div className="card-flip">
+                      <div className="card front">
+                        <Jumbotron key={card.id}>{card.wordEn}</Jumbotron>
+                      </div>
+                      <div className="card back">
+                        <Jumbotron key={card.id}>{card.wordNl}</Jumbotron>
+                      </div>
+                    </div>
+                  </div>
+                  <br />
+                  <div
+                    className="btn-group"
+                    role="group"
+                    aria-label="Basic example"
+                  >
+                    <Button className="btn-outline-info" variant="light">
+                      &#9664;
+                      {/* &#11207; */}
+                    </Button>
+                    <Button className="btn-outline-success" variant="light">
+                      &#x2714;
+                    </Button>{" "}
+                    <Button className="btn-outline-info" variant="light">
+                      &#128266;
+                    </Button>{" "}
+                    <Button className="btn-outline-danger" variant="light">
+                      &#x2716;
+                    </Button>
+                    <Button
+                      className="btn-outline-info"
+                      variant="light"
+                      onClick={() => {
+                        setIndex(++index);
+                      }}
+                    >
+                      &#9654;
+                      {/* &#11208; */}
+                    </Button>
+                  </div>
+                </div>
+                <br />
+                <div className="progress">
+                  <div
+                    className="progress-bar bg-info"
+                    role="progressbar"
+                    style={{ width: `${widthProgressBar}%` }}
+                    aria-valuemin="0"
+                    aria-valuemax={cardCount}
+                  >
+                    {`${index}/${cardCount}`}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+        })}
+      </div>
+    );
+  } else if (index > cardCount - 1) {
+    return (
+      <div>
+        {cards.map((card, cardIndex) => {
+          //see REFERENCES.md
+          if (
+            cardIndex === ((index % cardCount) + cardCount) % cardCount &&
+            card.collectionId === ID
+          ) {
+            return (
+              <div key={card.id} className="text-info">
+                <div className="Card2">
+                  <div className="card-container">
+                    <div className="card-flip">
+                      <div className="card front">
+                        <Jumbotron key={card.id}>{card.wordEn}</Jumbotron>
+                      </div>
+                      <div className="card back">
+                        <Jumbotron key={card.id}>{card.wordNl}</Jumbotron>
+                      </div>
+                    </div>
+                  </div>
+                  <br />
+                  <div
+                    className="btn-group"
+                    role="group"
+                    aria-label="Basic example"
+                  >
+                    <Button
+                      className="btn-outline-info"
+                      variant="light"
+                      onClick={() => {
+                        setIndex(--index);
+                      }}
+                    >
+                      &#9664;
+                      {/* &#11207; */}
+                    </Button>
+                    <Button className="btn-outline-success" variant="light">
+                      &#x2714;
+                    </Button>{" "}
+                    <Button className="btn-outline-info" variant="light">
+                      &#128266;
+                    </Button>{" "}
+                    <Button className="btn-outline-danger" variant="light">
+                      &#x2716;
+                    </Button>
+                    <Button className="btn-outline-info" variant="light">
+                      &#9654;
+                      {/* &#11208; */}
+                    </Button>
+                  </div>
+                </div>
+                <br />
+                <div className="progress">
+                  <div
+                    className="progress-bar bg-info"
+                    role="progressbar"
+                    style={{ width: `${widthProgressBar}%` }}
+                    aria-valuemin="0"
+                    aria-valuemax={cardCount}
+                  >
+                    {`${index}/${cardCount}`}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+        })}
+      </div>
+    );
+  }
 
   return (
     <div>
       {cards.map((card, cardIndex) => {
         //see REFERENCES.md
-        if (cardIndex === ((index % cardCount) + cardCount) % cardCount) {
+        if (
+          cardIndex === ((index % cardCount) + cardCount) % cardCount &&
+          card.collectionId === ID
+        ) {
           return (
             <div key={card.id} className="text-info">
               <div className="Card2">
@@ -37,10 +189,14 @@ export default function Card({ cards }) {
                       setIndex(--index);
                     }}
                   >
-                    &#11207;
+                    &#9664;
+                    {/* &#11207; */}
                   </Button>
                   <Button className="btn-outline-success" variant="light">
                     &#x2714;
+                  </Button>{" "}
+                  <Button className="btn-outline-info" variant="light">
+                    &#128266;
                   </Button>{" "}
                   <Button className="btn-outline-danger" variant="light">
                     &#x2716;
@@ -52,11 +208,23 @@ export default function Card({ cards }) {
                       setIndex(++index);
                     }}
                   >
-                    &#11208;
+                    &#9654;
+                    {/* &#11208; */}
                   </Button>
                 </div>
               </div>
               <br />
+              <div className="progress">
+                <div
+                  className="progress-bar bg-info"
+                  role="progressbar"
+                  style={{ width: `${widthProgressBar}%` }}
+                  aria-valuemin="0"
+                  aria-valuemax={cardCount}
+                >
+                  {`${index}/${cardCount}`}
+                </div>
+              </div>
             </div>
           );
         }
@@ -64,23 +232,3 @@ export default function Card({ cards }) {
     </div>
   );
 }
-
-//<div className="row-lg-4 card-container">
-
-// function ControlledCarousel() {
-//   const [index, setIndex] = useState(0);
-
-//   const handleSelect = (selectedIndex, e) => {
-//     setIndex(selectedIndex);
-//   };
-
-//   return (
-//     <Carousel activeIndex={index} onSelect={handleSelect}>
-//       <Carousel.Item>
-//         ITEM
-//       </Carousel.Item>
-//     </Carousel>
-//   );
-// }
-
-// render(<ControlledCarousel />);

--- a/src/components/CollectionCard.js
+++ b/src/components/CollectionCard.js
@@ -3,10 +3,14 @@ import Jumbotron from "react-bootstrap/Jumbotron";
 import Tooltip from "react-bootstrap/Tooltip";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import { Link } from "react-router-dom";
+import { selectToken } from "../store/user/selectors";
+import { useSelector } from "react-redux";
 
 export default function CollectionCard({ id, name, cards }) {
   //const resizedFont = { fontSize: "12px" };
   //<div style={resizedFont}>
+
+  const token = useSelector(selectToken);
 
   const tooltip = (
     <Tooltip id="tooltip">
@@ -15,17 +19,32 @@ export default function CollectionCard({ id, name, cards }) {
   );
 
   return (
-    <Link to={`/collections/${id}`} className="text-info">
-      <OverlayTrigger
-        placement="right"
-        delay={{ show: 230, hide: 250 }}
-        overlay={tooltip}
-      >
-        <Jumbotron>
-          <h3>{name}</h3>
-          {/* <div style={resizedFont}>{cards.length} cards</div> */}
-        </Jumbotron>
-      </OverlayTrigger>
-    </Link>
+    <div>
+      {token ? (
+        <Link to={`/collections/${id}`} className="text-info">
+          <OverlayTrigger
+            placement="right"
+            delay={{ show: 230, hide: 250 }}
+            overlay={tooltip}
+          >
+            <Jumbotron>
+              <h3>{name}</h3>
+            </Jumbotron>
+          </OverlayTrigger>
+        </Link>
+      ) : (
+        <Link to="#" className="text-info">
+          <OverlayTrigger
+            placement="right"
+            delay={{ show: 230, hide: 250 }}
+            overlay={tooltip}
+          >
+            <Jumbotron>
+              <h3>{name}</h3>
+            </Jumbotron>
+          </OverlayTrigger>
+        </Link>
+      )}
+    </div>
   );
 }

--- a/src/components/Navigation/LoggedIn.js
+++ b/src/components/Navigation/LoggedIn.js
@@ -4,6 +4,7 @@ import { logOut } from "../../store/user/actions";
 import Button from "react-bootstrap/Button";
 import { selectUser } from "../../store/user/selectors";
 import Nav from "react-bootstrap/Nav";
+import { Link } from "react-router-dom";
 
 export default function LoggedIn() {
   const dispatch = useDispatch();
@@ -11,9 +12,11 @@ export default function LoggedIn() {
   return (
     <>
       <Nav.Item style={{ padding: ".5rem 1rem" }}>{user.email}</Nav.Item>
-      <Button variant="info" onClick={() => dispatch(logOut())}>
-        Logout
-      </Button>
+      <Link to="/">
+        <Button variant="info" onClick={() => dispatch(logOut())}>
+          Logout
+        </Button>
+      </Link>
     </>
   );
 }

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -26,7 +26,11 @@ export default function Navigation() {
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav">
         <Nav style={{ width: "100%" }} fill>
-          <NavbarItem path="/" linkText="Home" />
+          {!token ? (
+            <NavbarItem path="/" linkText="Home" />
+          ) : (
+            <NavbarItem path="/user" linkText="MyProfile" />
+          )}
           {loginLogoutControls}
         </Nav>
       </Navbar.Collapse>

--- a/src/pages/EditPage.js
+++ b/src/pages/EditPage.js
@@ -1,0 +1,9 @@
+import React from "react";
+import "../style/Global.css";
+import "../style/CollectionCard.scss";
+
+const EditPage = () => {
+  return <div>Hallo</div>;
+};
+
+export default EditPage;

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -1,13 +1,46 @@
 import React, { useEffect } from "react";
 import { Jumbotron } from "react-bootstrap";
-// import { useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import CollectionCard from "../components/CollectionCard";
+import { selectCollections } from "../store/collection/selectors";
+import { fetchCollections } from "../store/collection/actions";
+import { selectUser } from "../store/user/selectors";
+import "../style/Global.css";
+import "../style/CollectionCard.scss";
 
 const UserPage = () => {
+  const dispatch = useDispatch();
+  const collections = useSelector(selectCollections);
+
+  const user = useSelector(selectUser);
+
+  useEffect(() => {
+    dispatch(fetchCollections());
+  }, [dispatch]);
+
+  const cardStyle = {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  };
+
   return (
     <div>
       <Jumbotron>
-        <h1>User profile (auth only)</h1>
+        <h1>Profile page</h1>
       </Jumbotron>
+
+      {collections.map((collection) => {
+        if (user.id === collection.userId) {
+          return (
+            <div style={cardStyle} key={collection.id}>
+              <div className="collectionCard" style={{ width: "20%" }}>
+                <CollectionCard key={collection.id} {...collection} />
+              </div>
+            </div>
+          );
+        }
+      })}
     </div>
   );
 };

--- a/src/style/Global.css
+++ b/src/style/Global.css
@@ -51,3 +51,13 @@ a.text-info:link {
   transition: all 0.6s ease;
 }
 /*end of flipping card transition*/
+
+/*progress bar animation*/
+/* .progress,
+.progress-bar {
+  height: 20px;
+  background: #69bd45;
+  width: 0;
+  transition: 0.5s;
+} */
+/*end of progress bar animation*/


### PR DESCRIPTION
- Added pages only accessible to loggedIn users
  - `UserPage` component (`"/user"`; personal profile, in which personal collections are mapped)
  - `EditPage` component (`"/edit"`, still empty; will provide a form to edit/create/delete collections/cards)
- Edited `NavBar`
  - deleted `Home` link (the `FlashcardApp` "logo" already provides such path)
  - added `MyProfile` link (`"/user"`)
- Added dynamic progress bar in carousel-like display in `CollectionPage`