### PR TITLE
Added actions/reducer/selector logic in session and scorecard stores so each session gets displayed with the current scores hold by state

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -26,12 +26,10 @@ const Card = ({ cards }) => {
           dispatch(finishSession(card.collectionId));
         }
         function setScore() {
-          console.log("card id", card.id);
           dispatch(assignScore(card.collectionId, card.id));
         }
 
         function setWrongScore() {
-          console.log("card id", card.id);
           dispatch(assignWrongScore(card.collectionId, card.id));
         }
         if (
@@ -86,6 +84,7 @@ const Card = ({ cards }) => {
                   <Button
                     className="btn-outline-danger"
                     variant="light"
+                    value={card.id}
                     onClick={setWrongScore}
                   >
                     &#x2716;
@@ -96,9 +95,7 @@ const Card = ({ cards }) => {
                       variant="light"
                       onClick={endSession}
                     >
-                      <Link to="/" exact>
-                        &#x1F51A;
-                      </Link>
+                      <Link to="/">&#x1F51A;</Link>
                     </Button>
                   ) : (
                     <Button
@@ -137,3 +134,6 @@ export default Card;
 
 /*&#9664; or &#11207;*/
 /*&#9654; or &#11208;*/
+
+//CORRECT &#x2714;
+//WRONG  &#x2716;

--- a/src/components/Navigation/index.js
+++ b/src/components/Navigation/index.js
@@ -26,16 +26,10 @@ export default function Navigation() {
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav">
         <Nav style={{ width: "100%" }} fill>
-          {!token ? (
-            <NavbarItem path="/" linkText="Home" />
-          ) : (
-            <NavbarItem path="/user" linkText="MyProfile" />
-          )}
+          {!token ? null : <NavbarItem path="/user" linkText="MyProfile" />}
           {loginLogoutControls}
         </Nav>
       </Navbar.Collapse>
     </Navbar>
   );
 }
-
-//DROPDOWN TO SELECT LANGUAGE??

--- a/src/pages/CollectionPage.js
+++ b/src/pages/CollectionPage.js
@@ -6,7 +6,9 @@ import { selectCollections } from "../store/collection/selectors";
 import { fetchCollections } from "../store/collection/actions";
 import { selectToken } from "../store/user/selectors";
 import { fetchSessions } from "../store/session/actions";
+import { selectSessionScoredCards } from "../store/session/selectors";
 import { useParams } from "react-router-dom";
+import { fetchScoredCards } from "../store/scoredcard/actions";
 
 const CollectionPage = () => {
   const dispatch = useDispatch();
@@ -14,10 +16,12 @@ const CollectionPage = () => {
   const routeParameters = useParams();
   const ID = parseInt(routeParameters.id);
   const token = useSelector(selectToken);
+  const scorecards = useSelector(selectSessionScoredCards);
 
   useEffect(() => {
     dispatch(fetchCollections());
     dispatch(fetchSessions(token));
+    dispatch(fetchScoredCards(token));
   }, [dispatch]);
 
   const cardStyle = {
@@ -33,10 +37,13 @@ const CollectionPage = () => {
           return (
             <div key={collection.id}>
               <Jumbotron>
-                <h1>{collection.name}</h1>{" "}
+                <h1>{collection.name}</h1>
                 <h5>{collection.cards.length} cards</h5>
+                <h5>
+                  &#x2714; {scorecards.scoredCorrect}, &#x2716;{" "}
+                  {scorecards.scoredIncorrect}
+                </h5>
               </Jumbotron>
-
               <div style={cardStyle} key={collection.cards.id}>
                 <div style={{ width: "15em" }}>
                   <Card key={collection.cards.id} {...collection} />
@@ -51,3 +58,50 @@ const CollectionPage = () => {
 };
 
 export default CollectionPage;
+
+//CORRECT &#x2714;
+//WRONG  &#x2716;
+
+//I still don't like waiting for the {scorecards.scoredCorrect}/{scorecards.scoredIncorrect} to load
+//but any change makes it impossible for the first score to be scoredIncorrect AND re-render (???)
+
+//EXAMPLES VVV
+
+// {scorecards.scoredCorrect ? (
+//   <div>
+//     <h5>
+//       &#x2714; {scorecards.scoredCorrect}, &#x2716;{" "}
+//       {scorecards.scoredIncorrect}
+//     </h5>
+//   </div>
+// ) : (
+//   <div>
+//     <h5>Start playing to see your score!</h5>
+//   </div>
+// )}
+
+//ONLY RE-RENDERS IF scoredCorrect (???)
+
+//I needed an ternary if/else operator (?) or something similar
+//so
+//a ? b : (c ? d : e)
+
+// {scorecards.scoredCorrect ? (
+//   <div>
+//     <h5>
+//       &#x2714; {scorecards.scoredCorrect}, &#x2716;{" "}
+//       {scorecards.scoredIncorrect}
+//     </h5>
+//   </div>
+// ) : !scorecards.scoredCorrect ? (
+//   <h5>
+//     &#x2714; {scorecards.scoredCorrect}, &#x2716;{" "}
+//     {scorecards.scoredIncorrect}
+//   </h5>
+// ) : (
+//   <div>
+//     <h5>Start playing to see your score!</h5>
+//   </div>
+// )}
+
+//THIS WORKED. BUT: TOO VERBOSE/UNMAINTAINABLE/MESSY

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -32,7 +32,6 @@ const Home = () => {
       </Jumbotron>
 
       <div className="row">
-        <br />
         {sortedCollections.map((collection) => {
           return (
             <div key={collection.id}>

--- a/src/store/scoredcard/actions.js
+++ b/src/store/scoredcard/actions.js
@@ -11,10 +11,10 @@ export const saveActiveScoredCard = (scoredCard) => ({
   payload: scoredCard,
 });
 
-// export const saveFinishedSession = (session) => ({
-//   type: "SAVE_FINISHED_SESSIONS",
-//   payload: session,
-// });
+export const addSessionScorecards = (scoredCard) => ({
+  type: "ADD_SESSION_SCOREDCARD",
+  payload: scoredCard,
+});
 
 export const fetchScoredCards = (token) => async (dispatch, getState) => {
   try {
@@ -33,15 +33,12 @@ export const assignScore = (collectionId, cardId) => async (
   getState
 ) => {
   try {
-    // console.log("what is card id", cardId);
     const { token } = getState().user;
-
-    let scoredCorrect = true;
 
     const response = await axios.patch(
       `${apiUrl}/scoredcards/collections/${collectionId}/${cardId}`,
       {
-        scoredCorrect,
+        scoredCorrect: true,
         cardId: cardId,
       },
       {
@@ -51,7 +48,8 @@ export const assignScore = (collectionId, cardId) => async (
       }
     );
 
-    dispatch(saveScoredCards(response.data));
+    dispatch(saveActiveScoredCard(response.data));
+    dispatch(addSessionScorecards(response.data));
   } catch (error) {
     console.log(error);
   }
@@ -64,12 +62,10 @@ export const assignWrongScore = (collectionId, cardId) => async (
   try {
     const { token } = getState().user;
 
-    let scoredCorrect = false;
-
     const response = await axios.patch(
       `${apiUrl}/scoredcards/collections/${collectionId}/${cardId}`,
       {
-        scoredCorrect,
+        scoredCorrect: false,
         cardId: cardId,
       },
       {
@@ -80,6 +76,7 @@ export const assignWrongScore = (collectionId, cardId) => async (
     );
 
     dispatch(saveActiveScoredCard(response.data));
+    dispatch(addSessionScorecards(response.data));
   } catch (error) {
     console.log(error);
   }

--- a/src/store/scoredcard/reducer.js
+++ b/src/store/scoredcard/reducer.js
@@ -1,16 +1,21 @@
 const initialState = {
   all: [],
   active: undefined,
+  sessionCards: [],
 };
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case "SAVE_SCOREDCARDS":
-      // console.log("what is payload", action.payload);
       return { ...state, all: action.payload };
     case "SAVE_ACTIVE_SCOREDCARD":
-      console.log("what is payload", action.payload);
-      return { ...state, active: action.payload };
+      return {
+        ...state,
+        active: action.payload,
+        all: [...state.all, action.payload],
+      };
+    case "ADD_SESSION_SCOREDCARD":
+      return { ...state, scoredCards: [...state.scoredCards, action.payload] };
     default:
       return state;
   }

--- a/src/store/scoredcard/selectors.js
+++ b/src/store/scoredcard/selectors.js
@@ -1,1 +1,3 @@
-export const selectScoredCards = (state) => state.scoredcards.all.scoredcards;
+export const selectScoredCards = (state) => state.scoredcards.all;
+
+export const selectActiveScoredCards = (state) => state.scoredcards.active;

--- a/src/store/session/reducer.js
+++ b/src/store/session/reducer.js
@@ -10,7 +10,6 @@ export default (state = initialState, action) => {
     case "SAVE_ACTIVE_SESSIONS":
       return { ...state, active: action.payload };
     case "SAVE_FINISHED_SESSIONS":
-      // console.log("what is the payload", action.payload);
       return { ...state, active: action.payload };
     default:
       return state;

--- a/src/store/session/selectors.js
+++ b/src/store/session/selectors.js
@@ -1,1 +1,59 @@
 export const selectSessions = (state) => state.sessions.all;
+export const selectSessionScoredCards = (state) => {
+  console.log("what is state", state);
+  if (!state.scoredcards) {
+    return {};
+  }
+
+  if (!state.sessions.active) {
+    return {};
+  }
+
+  const scoredcards = state.scoredcards.all;
+  const activeSessionID = state.sessions.active.id;
+
+  const scoredCorrect = scoredcards.filter((card) => {
+    if (card.sessionId === activeSessionID && card.scoredCorrect === true) {
+      return card;
+    }
+  });
+  const scoredIncorrect = scoredcards.filter((card) => {
+    if (card.sessionId === activeSessionID && card.scoredCorrect === false) {
+      return card;
+    }
+  });
+
+  return {
+    scoredCorrect: scoredCorrect.length,
+    scoredIncorrect: scoredIncorrect.length,
+  };
+};
+
+//SIDENOTE: the selectSessionScoredCards selector works but needs some more logic: a user can technically go back
+//and score the same cards how many times they wish,
+//and it messes up the active session card count
+
+export const selectActiveSession = (state) => state.sessions.active;
+
+// WORKED BUT VVV
+// export const selectSessions = (state) => state.sessions.all;
+// export const selectSessionScoredCards = (state) => {
+//   console.log("this is state", state.scoredcards.all);
+//   console.log("this is the active session", state.sessions.active);
+
+//   if (!state.scoredcards) {
+//     return {};
+//   }
+//   const scoredcards = state.scoredcards.all;
+//   const scoredCorrect = scoredcards.filter((card) => {
+//     return card.scoredCorrect;
+//   });
+//   const scoredIncorrect = scoredcards.length - scoredCorrect.length;
+
+//   return {
+//     scoredCorrect: scoredCorrect.length,
+//     scoredIncorrect,
+//   };
+// };
+
+// export const selectActiveSession = (state) => state.sessions.active;


### PR DESCRIPTION
- Added actions/reducer/selector logic in `session` and `scorecard` stores so each session can access all the `scoredCards`
- Added logic so that the `scoredCards` are filtered by `session` so the scores can be displayed/rendered while the user's playing

Sidenotes:
- in `src/store/session/selectors.js`
  the `selectSessionScoredCards` selector works but needs some more logic: a user can _technically_ go back and score the same cards how many times they wish, and it messes up the active session card count
- in `/src/pages/CollectionPage.js`
  I still don't like waiting for the `{scorecards.scoredCorrect}`/`{scorecards.scoredIncorrect}` to load but any change makes it impossible for the first score to be `scoredIncorrect` AND re-render <kbd>???</kbd>. The first score _ONLY RE-RENDERS IF `scoredCorrect`_