### PR TITLE
Added components and logic to display user stats filtered by active collection

### DIFF
--- a/src/pages/CollectionPage.js
+++ b/src/pages/CollectionPage.js
@@ -5,8 +5,14 @@ import Card from "../components/Card";
 import { selectCollections } from "../store/collection/selectors";
 import { fetchCollections } from "../store/collection/actions";
 import { selectToken } from "../store/user/selectors";
-import { fetchSessions } from "../store/session/actions";
-import { selectSessionScoredCards } from "../store/session/selectors";
+import {
+  fetchSessions,
+  getUserCollectionSessions,
+} from "../store/session/actions";
+import {
+  selectSessionScoredCards,
+  selectScores,
+} from "../store/session/selectors";
 import { useParams } from "react-router-dom";
 import { fetchScoredCards } from "../store/scoredcard/actions";
 
@@ -17,11 +23,13 @@ const CollectionPage = () => {
   const ID = parseInt(routeParameters.id);
   const token = useSelector(selectToken);
   const scorecards = useSelector(selectSessionScoredCards);
+  const scores = useSelector(selectScores);
 
   useEffect(() => {
     dispatch(fetchCollections());
     dispatch(fetchSessions(token));
     dispatch(fetchScoredCards(token));
+    dispatch(getUserCollectionSessions(ID));
   }, [dispatch]);
 
   const cardStyle = {
@@ -49,6 +57,49 @@ const CollectionPage = () => {
                   <Card key={collection.cards.id} {...collection} />
                 </div>
               </div>
+              <Jumbotron style={{ width: "22em" }}>
+                <strong>User stats</strong>
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th scope="col"></th>
+                      <th scope="col">Correct</th>
+                      <th scope="col">Total</th>
+                      <th scope="col">Score</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {scores.map((session, index) => {
+                      const correct = session.scoredCards.filter(
+                        (card) => card.scoredCorrect === true
+                      );
+
+                      const percentage = parseInt(
+                        (100 / session.scoredCards.length) * correct.length
+                      );
+
+                      return (
+                        <tr
+                          key={index}
+                          style={index % 2 ? { backgroundColor: "#CCC" } : null}
+                        >
+                          <td
+                            scope="row"
+                            style={{
+                              backgroundColor: "#CCC",
+                            }}
+                          >
+                            #{index + 1}
+                          </td>
+                          <td>{correct.length}</td>
+                          <td>{session.scoredCards.length}</td>
+                          <td>{percentage}%</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </Jumbotron>
             </div>
           );
         }

--- a/src/store/session/actions.js
+++ b/src/store/session/actions.js
@@ -16,6 +16,11 @@ export const saveFinishedSession = (session) => ({
   payload: session,
 });
 
+export const saveUserCollectionStats = (sessions) => ({
+  type: "SAVE_USER_COLLECTION_STATS",
+  payload: sessions,
+});
+
 export const fetchSessions = (token) => async (dispatch, getState) => {
   try {
     const response = await axios.get(`${apiUrl}/sessions/`, {
@@ -72,6 +77,28 @@ export const finishSession = (collectionId, finished) => async (
     );
 
     dispatch(saveFinishedSession(response.data));
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const getUserCollectionSessions = (collectionId) => async (
+  dispatch,
+  getState
+) => {
+  try {
+    const { token } = getState().user;
+
+    const response = await axios.get(
+      `${apiUrl}/sessions/stats/${collectionId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    dispatch(saveUserCollectionStats(response.data));
   } catch (error) {
     console.log(error);
   }

--- a/src/store/session/reducer.js
+++ b/src/store/session/reducer.js
@@ -1,6 +1,7 @@
 const initialState = {
   all: [],
   active: undefined,
+  stats: [],
 };
 
 export default (state = initialState, action) => {
@@ -11,6 +12,8 @@ export default (state = initialState, action) => {
       return { ...state, active: action.payload };
     case "SAVE_FINISHED_SESSIONS":
       return { ...state, active: action.payload };
+    case "SAVE_USER_COLLECTION_STATS":
+      return { ...state, stats: action.payload };
     default:
       return state;
   }

--- a/src/store/session/selectors.js
+++ b/src/store/session/selectors.js
@@ -1,6 +1,6 @@
 export const selectSessions = (state) => state.sessions.all;
+
 export const selectSessionScoredCards = (state) => {
-  // console.log("what is state", state);
   if (!state.scoredcards) {
     return {};
   }
@@ -34,6 +34,7 @@ export const selectSessionScoredCards = (state) => {
 //and it messes up the active session card count
 
 export const selectActiveSession = (state) => state.sessions.active;
+export const selectScores = (state) => state.sessions.stats;
 
 // WORKED BUT VVV
 // export const selectSessions = (state) => state.sessions.all;


### PR DESCRIPTION
- Added table in `UserPage` component to display stats
  - num. `scoredCorrect` **/** num. total scores ratio
  - a percentage of said ratio is calculated
- Added logic to send a GET request to the backend to get logged user `session` data:
  - only sessions belonging to the logged user **and** to the active collection are taken into consideration
  - sessions without `scoredCards` are filtered out by default
  - sessions do _not_ need to be `finished` to be taken into account
    - user might want to test themselves over and over again
      <kbd>(num. scoredCards > num. cards in the collection)</kbd>
    - user might not finish the current session (`finished` === `true`), yet their progress shouldn't be filtered out
      <kbd>(num. scoredCards < num. cards in the collection)</kbd>